### PR TITLE
add PerformActions with Pointer and Wheel

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -25,6 +25,14 @@ func (a *Actions) Wheel(id string) (ret *InputActions) {
 	return
 }
 
+func (a *Actions) Key() (ret *InputActions) {
+	ret = &InputActions{
+		Type: "key",
+	}
+	a.Actions = append(a.Actions, ret)
+	return
+}
+
 type InputActions struct {
 	Type       string `json:"type"`
 	Id         string `json:"id,omitEmpty"`
@@ -55,6 +63,13 @@ func (ia *InputActions) Add(action any) {
 
 	case Scroll:
 		v.Type = "scroll"
+		ia.Actions = append(ia.Actions, v)
+
+	case KeyUp:
+		v.Type = "keyUp"
+		ia.Actions = append(ia.Actions, v)
+	case KeyDown:
+		v.Type = "keyDown"
 		ia.Actions = append(ia.Actions, v)
 
 	default:
@@ -91,4 +106,13 @@ type Scroll struct {
 	Y        int    `json:"y"`
 	DeltaX   int    `json:"deltaX"`
 	DeltaY   int    `json:"deltaY"`
+}
+
+type KeyDown struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+type KeyUp struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }

--- a/actions.go
+++ b/actions.go
@@ -1,0 +1,94 @@
+package marionette
+
+type Actions struct {
+	Actions []*InputActions `json:"actions"`
+}
+
+func (a *Actions) Pointer(id, pointerType string) (ret *InputActions) {
+	ret = &InputActions{
+		Type: "pointer",
+		Id:   id,
+		Parameters: PointerParameters{
+			PointerType: pointerType,
+		},
+	}
+	a.Actions = append(a.Actions, ret)
+	return
+}
+
+func (a *Actions) Wheel(id string) (ret *InputActions) {
+	ret = &InputActions{
+		Type: "wheel",
+		Id:   id,
+	}
+	a.Actions = append(a.Actions, ret)
+	return
+}
+
+type InputActions struct {
+	Type       string `json:"type"`
+	Id         string `json:"id,omitEmpty"`
+	Parameters any    `json:"parameters,omitEmpty"`
+	Actions    []any  `json:"actions"`
+}
+
+type PointerParameters struct {
+	// PointerType is "mouse", "pen" or "touch"
+	PointerType string `json:"pointerType,omitempty"`
+}
+
+func (ia *InputActions) Add(action any) {
+	switch v := action.(type) {
+	case Pause:
+		v.Type = "pause"
+		ia.Actions = append(ia.Actions, v)
+
+	case PointerMove:
+		v.Type = "pointerMove"
+		ia.Actions = append(ia.Actions, v)
+	case PointerUp:
+		v.Type = "pointerUp"
+		ia.Actions = append(ia.Actions, v)
+	case PointerDown:
+		v.Type = "pointerDown"
+		ia.Actions = append(ia.Actions, v)
+
+	case Scroll:
+		v.Type = "scroll"
+		ia.Actions = append(ia.Actions, v)
+
+	default:
+		panic("invalid action")
+	}
+}
+
+type Pause struct {
+	Type     string `json:"type"`
+	Duration int    `json:"duration"`
+}
+
+type PointerMove struct {
+	Type     string `json:"type"`
+	Duration int    `json:"duration"`
+	Origin   string `json:"origin,omitempty"`
+	X        int    `json:"x"`
+	Y        int    `json:"y"`
+}
+type PointerUp struct {
+	Type   string `json:"type"`
+	Button int    `json:"button"`
+}
+type PointerDown struct {
+	Type   string `json:"type"`
+	Button int    `json:"button"`
+}
+
+type Scroll struct {
+	Type     string `json:"type"`
+	Duration int    `json:"duration"`
+	Origin   string `json:"origin,omitempty"`
+	X        int    `json:"x"`
+	Y        int    `json:"y"`
+	DeltaX   int    `json:"deltaX"`
+	DeltaY   int    `json:"deltaY"`
+}

--- a/client.go
+++ b/client.go
@@ -629,3 +629,8 @@ func (c *Client) Screenshot() ([]byte, error) {
 func (c *Client) ScreenshotImage() (image.Image, error) {
 	return c.takeScreenshotImage(nil)
 }
+
+func (c *Client) PerformActions(actions Actions) (*Response, error) {
+	r, err := c.tr.Send("WebDriver:PerformActions", actions)
+	return r, err
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/dennwc/marionette
+module github.com/mcluseau/marionette
 
 go 1.20


### PR DESCRIPTION
Hi,

PR if you want to integrate this. tldr, code to use:

pointer (here it's a drag):
```golang
	actions := marionette.Actions{}
	ptr := actions.Pointer("finger1", "touch")

	ptr.Add(marionette.PointerMove{X: x, Y: y})
	ptr.Add(marionette.PointerDown{})
	ptr.Add(marionette.PointerMove{Origin: "pointer", Duration: 50, X: dX, Y: dY})
	ptr.Add(marionette.PointerUp{})

	client.PerformActions(actions)
```

wheel:
```golang
		actions := marionette.Actions{}
		wh := actions.Wheel("wheel1")
		wh.Add(marionette.Scroll{
			X:      x,
			Y:      y,
			DeltaX: 0,
			DeltaY: 100,
		})
		client.PerformActions(actions)
```